### PR TITLE
fix: frame captures lose the race with saveFrameToPng's asynchronous write

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,12 @@ import {
 } from "./lib/bridge-core.js";
 import { collectPresetFiles } from "./lib/preset-scan.js";
 import { analyzeWavBuffer, WavAnalysis } from "./lib/wav.js";
-import { buildFrameContent, type FrameFile, type ContentBlock } from "./lib/see-frame.js";
+import {
+  buildFrameContent,
+  isCompletePng,
+  type FrameFile,
+  type ContentBlock,
+} from "./lib/see-frame.js";
 import {
   amplitudeAtTime,
   buildPeakKeyframes,
@@ -3003,13 +3008,13 @@ server.tool(
             : JSON.stringify(parsed.state)
           : undefined;
 
-      const readBase64 = (p: string): string | null => {
-        try {
-          return fs.readFileSync(p).toString("base64");
-        } catch {
-          return null;
-        }
-      };
+      const b64ByPath = new Map<string, string>();
+      for (const f of frames) {
+        if (!f || !f.path) continue;
+        const b64 = await readScratchPngBase64(f.path);
+        if (b64 !== null) b64ByPath.set(f.path, b64);
+      }
+      const readBase64 = (p: string): string | null => b64ByPath.get(p) ?? null;
 
       const content: ContentBlock[] = buildFrameContent(compName, frames, readBase64, stateJson);
       if (parsed.note) content.push({ type: "text", text: String(parsed.note) });
@@ -3033,13 +3038,34 @@ server.tool(
   },
 );
 
+// saveFrameToPng returns before the render finishes: After Effects queues the
+// frame and writes the PNG asynchronously, so the bridge result JSON usually
+// arrives before the file exists on disk, and an early read can even succeed
+// with a truncated PNG (observed on AE 2026 / Windows; the ExtendScript side
+// works around the same lag with _importWithRetry). Poll until the file is a
+// structurally complete PNG before accepting the bytes. The timeout is generous
+// because a multi-frame batch renders sequentially after the script returns.
+async function readScratchPngBase64(p: string, timeoutMs = 15000): Promise<string | null> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const buf = fs.readFileSync(p);
+      if (isCompletePng(buf)) return buf.toString("base64");
+    } catch {
+      // not written yet
+    }
+    if (Date.now() >= deadline) return null;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+}
+
 // Read scratch PNGs listed in a bridge result into MCP image blocks, then delete
 // them. Shared by contact-sheet and match-reference.
-function imageResultFromPaths(
+async function imageResultFromPaths(
   raw: string,
   entries: Array<{ path?: string; caption: string }>,
   headerText: string,
-): { content: ContentBlock[]; isError?: boolean } {
+): Promise<{ content: ContentBlock[]; isError?: boolean }> {
   const cleanup: string[] = [];
   try {
     let parsed: any;
@@ -3055,12 +3081,7 @@ function imageResultFromPaths(
     for (const e of entries) {
       if (!e.path) continue;
       cleanup.push(e.path);
-      let b64: string | null = null;
-      try {
-        b64 = fs.readFileSync(e.path).toString("base64");
-      } catch {
-        b64 = null;
-      }
+      const b64 = await readScratchPngBase64(e.path);
       if (b64) {
         content.push({ type: "text", text: e.caption });
         content.push({ type: "image", data: b64, mimeType: "image/png" });

--- a/src/lib/see-frame.ts
+++ b/src/lib/see-frame.ts
@@ -76,6 +76,28 @@ export function scratchFramePath(dir: string, commandId: string, index: number):
 }
 
 /**
+ * Structural completeness check for a PNG byte buffer. After Effects'
+ * saveFrameToPng returns before the render finishes and writes the PNG
+ * asynchronously, so a reader polling the scratch folder can observe a missing
+ * or partially-written file. A complete PNG starts with the 8-byte PNG
+ * signature and ends with the IEND chunk, whose trailing 8 bytes ("IEND" plus
+ * its constant CRC) are invariant across all PNGs.
+ */
+export function isCompletePng(buf: Uint8Array): boolean {
+  const SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+  const IEND_TAIL = [0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82];
+  if (buf.length < SIGNATURE.length + 12) return false;
+  for (let i = 0; i < SIGNATURE.length; i++) {
+    if (buf[i] !== SIGNATURE[i]) return false;
+  }
+  const off = buf.length - IEND_TAIL.length;
+  for (let i = 0; i < IEND_TAIL.length; i++) {
+    if (buf[off + i] !== IEND_TAIL[i]) return false;
+  }
+  return true;
+}
+
+/**
  * Sample N evenly-spaced times across [0, duration] for a contact sheet. Returns
  * the midpoints of N equal segments (so no frame sits exactly at t=0 or t=dur,
  * which often render empty at the very edges). count is clamped to [1, 64].

--- a/tests/see-frame.test.ts
+++ b/tests/see-frame.test.ts
@@ -6,6 +6,7 @@ import {
   buildFrameContent,
   sampleTimes,
   gridLayout,
+  isCompletePng,
 } from "../src/lib/see-frame";
 
 describe("normalizeTimes", () => {
@@ -147,5 +148,33 @@ describe("buildFrameContent", () => {
     const blocks = buildFrameContent("Intro", [{ time: 0, path: "/a.png" }], read);
     expect((blocks[0] as { text: string }).text).toContain("1 frame");
     expect((blocks[0] as { text: string }).text).not.toContain("frames");
+  });
+});
+
+describe("isCompletePng", () => {
+  const SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+  const IEND_CHUNK = [0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82];
+  const minimalPng = (middle: number[] = []) =>
+    Uint8Array.from([...SIGNATURE, ...middle, ...IEND_CHUNK]);
+
+  it("accepts a structurally complete PNG (signature + IEND trailer)", () => {
+    expect(isCompletePng(minimalPng())).toBe(true);
+    expect(isCompletePng(minimalPng([1, 2, 3, 4, 5, 6, 7, 8, 9]))).toBe(true);
+  });
+
+  it("rejects a truncated PNG missing its IEND trailer", () => {
+    const full = minimalPng([1, 2, 3, 4]);
+    const truncated = full.slice(0, full.length - 5);
+    expect(isCompletePng(truncated)).toBe(false);
+  });
+
+  it("rejects an empty or too-short buffer", () => {
+    expect(isCompletePng(Uint8Array.from([]))).toBe(false);
+    expect(isCompletePng(Uint8Array.from(SIGNATURE))).toBe(false);
+  });
+
+  it("rejects a non-PNG buffer even if it happens to end with the IEND bytes", () => {
+    const notPng = Uint8Array.from([...new TextEncoder().encode("hello   "), ...IEND_CHUNK]);
+    expect(isCompletePng(notPng)).toBe(false);
   });
 });


### PR DESCRIPTION
## What

`see-frame`, `contact-sheet`, and `match-reference` read the scratch PNGs the panel writes with a single immediate `fs.readFileSync`. That read races the actual file write and loses in two ways:

- **Frame reported unreadable** ("frame at t=Ns could not be read") when the file does not exist yet
- **Corrupt image returned** when the read lands mid-write and succeeds with a truncated PNG

Multi-frame `times: [...]` captures fail almost every time; single-frame captures fail intermittently.

## Why

`saveFrameToPng` is asynchronous: the ExtendScript call returns once the frame render is queued, and After Effects writes the PNG in the background. The panel therefore writes the bridge result JSON (and the server starts reading) before the files exist. The `_importWithRetry` comment in `mcp-bridge-auto.jsx` attributes the same lag to an OS write-lock, but the behavior is a queued background render.

Observed against a live After Effects 2026 (26.3) on Windows 11: a script that calls `saveFrameToPng` for 16 frames returned with only 7 PNGs on disk and one file mid-write; the remaining files appeared over the following seconds.

## How

- New pure helper `isCompletePng()` in `src/lib/see-frame.ts`: checks the 8-byte PNG signature and the constant 8-byte IEND trailer, so a partially-written file is never accepted.
- `readScratchPngBase64()` in `src/index.ts` polls each scratch path (100ms interval, 15s deadline) until the bytes pass that check, then returns the base64. Used by `see-frame` directly and by `imageResultFromPaths` (shared by `contact-sheet` and `match-reference`, both now awaited).
- The generous per-file deadline matters for multi-frame batches, which render sequentially after the script returns.

No bridge (`mcp-bridge-auto.jsx`) changes, so no `BRIDGE_VERSION` bump is needed and existing installed panels keep working.

## Testing

- `npm run typecheck`, `npm test` (115 passing, including 4 new `isCompletePng` cases: complete, truncated, too-short, wrong-signature), `npm run build`
- Exercised against live AE 2026 on Windows 11 while building out a 7-composition project through the MCP: reproduced both failure modes with the old code path and confirmed the diagnosis by watching the scratch folder during batch captures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
